### PR TITLE
[#11] Sequence Picker

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,1 +1,4 @@
-{}
+{
+  "POLO.SequencePicker": "Sequence Picker",
+  "POLO.AllGucci": "All Gucci"
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,4 @@
 {
   "POLO.SequencePicker": "Sequence Picker",
-  "POLO.AllGucci": "All Gucci"
+  "POLO.Done": "Done"
 }

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
     {
       "name": "Zhell",
       "url": "https://github.com/krbz999",
-      "discord": "Zhell9201",
+      "discord": "zhell9201",
       "ko-fi": "https://ko-fi.com/zhell",
       "patreon": "https://patreon.com/zhell"
     },
@@ -31,7 +31,9 @@
       "path": "lang/en.json"
     }
   ],
-  "styles": [],
+  "styles": [
+    "styles/sequence-picker.css"
+  ],
   "socket": true,
   "url": "",
   "manifest": "",

--- a/module.mjs
+++ b/module.mjs
@@ -1,8 +1,8 @@
 import * as utils from "./scripts/utils.mjs";
-export const MODULE_ID = "polo-utils"; 
+export const MODULE_ID = "polo-utils";
 
 
-Hooks.once("ready", ()=>{
+Hooks.once("ready", () => {
   game.modules.get(MODULE_ID).utils = utils;
   globalThis.polo = game.modules.get(MODULE_ID);
-})
+});

--- a/scripts/applications/module.mjs
+++ b/scripts/applications/module.mjs
@@ -1,0 +1,4 @@
+import {SequencePicker} from "./sequence-picker.mjs";
+export default {
+  sequence: SequencePicker
+};

--- a/scripts/applications/sequence-picker.mjs
+++ b/scripts/applications/sequence-picker.mjs
@@ -120,6 +120,12 @@ export class SequencePicker extends Dialog {
       spr.anchor.set(0.5);
       spr.height = spr.width = canvas.grid.size;
       const sprite = canvas.effects.addChildAt(spr, point);
+      const mask = new PIXI.Graphics()
+        .beginFill("WHITE",1)
+        .drawCircle(0, 0, 0.5 * sprite.texture.baseTexture.width)
+        .endFill();
+      sprite.addChild(mask);
+      sprite.mask = mask;
       this.sprites.add(sprite);
     }
     return super.render(...args);

--- a/scripts/applications/sequence-picker.mjs
+++ b/scripts/applications/sequence-picker.mjs
@@ -115,7 +115,7 @@ export class SequencePicker extends Dialog {
     const img = "icons/sundries/flags/banner-flag-blue.webp";
     this.sprites = new Set();
     for (const point of points) {
-      const spr = PIXI.Sprite.from(img, {scale: 0.5});
+      const spr = PIXI.Sprite.from(img);
       Object.assign(spr, point);
       spr.anchor.set(0.5);
       spr.height = spr.width = canvas.grid.size;

--- a/scripts/applications/sequence-picker.mjs
+++ b/scripts/applications/sequence-picker.mjs
@@ -6,10 +6,10 @@ class SequencePickerModel extends foundry.abstract.DataModel {
   static defineSchema() {
     const fields = foundry.data.fields;
     return {
-      links: new fields.NumberField({min: 0, integer: true}),
+      links: new fields.NumberField({positive: true, integer: true}),
       sequence: new fields.SetField(new fields.SchemaField({
-        x: new fields.NumberField(),
-        y: new fields.NumberField()
+        x: new fields.NumberField({step: 0.5}),
+        y: new fields.NumberField({step: 0.5})
       }))
     };
   }
@@ -88,10 +88,8 @@ export class SequencePicker extends Application {
 
   /** Handle click events on the canvas. */
   _onClickCanvas() {
-    let {x, y} = canvas.mousePosition;
-    x = x.toNearest(0.5);
-    y = y.toNearest(0.5);
-    const sequence = [...this.model.sequence, {x, y}].slice(0, this.model.links);
+    const point = canvas.mousePosition;
+    const sequence = [...this.model.sequence, point].slice(0, this.model.links);
     this.model.updateSource({sequence: sequence});
     this.render();
   }

--- a/scripts/applications/sequence-picker.mjs
+++ b/scripts/applications/sequence-picker.mjs
@@ -25,11 +25,7 @@ export class SequencePicker extends Application {
   constructor(config = {}) {
     super({});
     this.callback = config.callback ?? (() => {});
-    config = foundry.utils.mergeObject({
-      links: 10,
-      distance: 60,
-      sequence: []
-    }, config);
+    config = foundry.utils.mergeObject({links: 10, sequence: []}, config);
     if ("origin" in config) config.sequence.unshift(config.origin);
     this.model = new SequencePickerModel(config);
   }

--- a/scripts/applications/sequence-picker.mjs
+++ b/scripts/applications/sequence-picker.mjs
@@ -1,0 +1,145 @@
+/**
+ * A utility application to pick a sequence of targets.
+ */
+
+class SequencePickerModel extends foundry.abstract.DataModel {
+  /** @override */
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return {
+      linkDistance: new fields.NumberField({min: 0}),
+      links: new fields.NumberField({min: 0, integer: true}),
+      maxDistance: new fields.NumberField({min: 0}),
+      sequence: new fields.SetField(new fields.SchemaField({
+        x: new fields.NumberField(),
+        y: new fields.NumberField()
+      }))
+    };
+  }
+}
+
+export class SequencePicker extends Dialog {
+  /**
+   * @constructor
+   * @param {number} [linkDistance=60]      The maximum distance between each link in the chain.
+   * @param {number} [links=10]             The maximum number of links in the chain.
+   * @param {object} [origin]               An originating point of the chain.
+   * @param {number} [maxDistance=60]       The maximum distance that any link in the chain is allowed from the origin.
+   * @param {object[]} [sequence=[]]        An array of points.
+   */
+  constructor(config = {}) {
+    super({});
+    this.callback = config.callback ?? (() => {});
+    config = foundry.utils.mergeObject({
+      linkDistance: 60,
+      links: 10,
+      maxDistance: 60,
+      sequence: []
+    }, config);
+    if ("origin" in config) config.sequence.unshift(config.origin);
+    this.model = new SequencePickerModel(config);
+  }
+
+  get title() {
+    return game.i18n.localize("POLO.SequencePicker");
+  }
+
+  /** @override */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      resizeable: false,
+      minimizable: false,
+      template: "modules/polo-utils/templates/applications/sequence-picker.hbs",
+      classes: ["sequence-picker"],
+      width: 200
+    });
+  }
+
+  /** @override */
+  async getData() {
+    const unplaced = "icons/sundries/flags/banner-flag-white-mountain.webp";
+    const placed = "icons/sundries/flags/banner-flag-blue.webp";
+
+    const sequence = new Array(this.model.links).fill({img: unplaced});
+    this.model.sequence.map((point, idx) => sequence[idx] = {point: point, img: placed});
+
+    const links = [...this.model.sequence];
+    const canAdd = links.length < this.model.links;
+
+    return {sequence, canAdd};
+  }
+
+  /** @override */
+  activateListeners(html) {
+    super.activateListeners(html);
+    if (!this.listener) {
+      const listener = this._onClickCanvas.bind(this);
+      canvas.app.stage.addEventListener("click", listener);
+      this.listener = listener;
+    }
+    html[0].querySelector("[data-action='submit']").addEventListener("click", this.submit.bind(this));
+  }
+
+  /** Handle click events on the canvas. */
+  _onClickCanvas() {
+    let {x, y} = canvas.mousePosition;
+    x = x.toNearest(0.5);
+    y = y.toNearest(0.5);
+    const sequence = [...this.model.sequence, {x, y}].slice(0, this.model.links);
+    this.model.updateSource({sequence: sequence});
+    this.render();
+  }
+
+  /**
+   * Handle clicking the finalize button.
+   * @param {PointerEvent} event      The initiating click event.
+   */
+  submit(event) {
+    this.callback(this.model.sequence);
+    this.close();
+  }
+
+  /** Destroy sprites. */
+  _destroySprites() {
+    const sprites = this.sprites ?? new Set();
+    for (const sprite of sprites) {
+      sprite.destroy();
+      sprites.delete(sprite);
+    }
+  }
+
+  /** @override */
+  async render(...args) {
+    this._destroySprites();
+    const points = this.model.sequence;
+    const img = "icons/sundries/flags/banner-flag-blue.webp";
+    this.sprites = new Set();
+    for (const point of points) {
+      const spr = PIXI.Sprite.from(img, {scale: 0.5});
+      Object.assign(spr, point);
+      spr.anchor.set(0.5);
+      spr.height = spr.width = canvas.grid.size;
+      const sprite = canvas.effects.addChildAt(spr, point);
+      this.sprites.add(sprite);
+    }
+    return super.render(...args);
+  }
+
+  /** @override */
+  async close(...args) {
+    canvas.app.stage.removeEventListener("click", this.listener);
+    this._destroySprites();
+    this.callback(null);
+    return super.close(...args);
+  }
+
+  /**
+   * Create an instance of this application and wait for the callback.
+   * @returns {Promise<object|null>}      An object of points, or null if closed.
+   */
+  static async create(config) {
+    return new Promise(resolve => {
+      new SequencePicker({...config, callback: resolve}).render(true);
+    });
+  }
+}

--- a/scripts/applications/sequence-picker.mjs
+++ b/scripts/applications/sequence-picker.mjs
@@ -50,7 +50,7 @@ export class SequencePicker extends Dialog {
       resizeable: false,
       minimizable: false,
       template: "modules/polo-utils/templates/applications/sequence-picker.hbs",
-      classes: ["sequence-picker"],
+      classes: ["polo-utils-sequence-picker"],
       width: 200
     });
   }

--- a/scripts/applications/sequence-picker.mjs
+++ b/scripts/applications/sequence-picker.mjs
@@ -30,9 +30,14 @@ export class SequencePicker extends Application {
     this.model = new SequencePickerModel(config);
   }
 
+  /**
+   * Images used for placed and unplaced points.
+   * @type {string}
+   */
   static PLACED_IMG = "icons/sundries/flags/banner-flag-blue.webp";
   static UNPLACED_IMG = "icons/sundries/flags/banner-flag-white-mountain.webp";
 
+  /** @override */
   get title() {
     return game.i18n.localize("POLO.SequencePicker");
   }
@@ -145,7 +150,6 @@ export class SequencePicker extends Application {
     pos.height = "auto";
     return super.setPosition(pos);
   }
-
 
   /**
    * Create an instance of this application and wait for the callback.

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,4 +1,5 @@
-import { MODULE_ID } from "../module.mjs";
+import {MODULE_ID} from "../module.mjs";
+import applications from "./applications/module.mjs";
 export {
   wait,
   updateTokenSight,
@@ -6,7 +7,8 @@ export {
   sortArray,
   rotateAround,
   playSoundForOthers,
-  getDefaultName
+  getDefaultName,
+  applications
 }
 
 /**
@@ -17,35 +19,35 @@ export {
  * @param {number} degrees                A number in degrees specifiying by how many degrees the point is to be rotated
  * @returns {object}                      The rotated point {x,y}
  */
-function rotateAround(point,pivot,degrees){
-  const degreesRad=Math.toRadians(degrees)
-  const sinus=Math.sin(degreesRad)
-  const cosinus=Math.cos(degreesRad)
-  
-  // Translate back to origin 
-  point.x-=pivot.x
-  point.y-=pivot.y
-  
+function rotateAround(point, pivot, degrees) {
+  const degreesRad = Math.toRadians(degrees)
+  const sinus = Math.sin(degreesRad)
+  const cosinus = Math.cos(degreesRad)
+
+  // Translate back to origin
+  point.x -= pivot.x
+  point.y -= pivot.y
+
   // Compute rotation
   const newPoint = {
     x: point.x * cosinus - point.y * sinus,
     y: point.x * sinus + point.y * cosinus
   }
-  
+
   // Add pivot back in and return
   return {x: newPoint.x + pivot.x, y: newPoint.y + pivot.y};
 }
 
- /**
- * @param {number} ms                        A time in milliseconds.
- * @returns {Promise<void>}                  A promise that resolves to a void.
- */
+/**
+* @param {number} ms                        A time in milliseconds.
+* @returns {Promise<void>}                  A promise that resolves to a void.
+*/
 async function wait(ms) {
   return new Promise(r => setTimeout(r, ms));
 }
 
 /**
- * Function to update the sight of a Token. Function takes both a token placeable and a token document, 
+ * Function to update the sight of a Token. Function takes both a token placeable and a token document,
  * as well as a config object, which can contain all the options for a Token's sight.
  * @param {Token|TokenDocument} token        A token or token document.
  * @param {object} config                    Configuration changes to the token's sight.
@@ -58,18 +60,18 @@ async function wait(ms) {
  * @param {number} config.range              Range of sight in canvas units (feet, meters etc.).
  * @param {number} config.saturation         Saturation of sight, between -1 and 1.
  * @param {string} config.visionMode         Vision mode, eg. darkvision or monochromatic etc.
- * 
+ *
  * @returns {Promise<null|TokenDocument>}    The updated token document.
- * 
+ *
  * @example Change a token's vision to Darkvision with a range of 60ft
  * ```js
  * await polo.utils.updateTokenSight(token, {visionMode: "darkvision", range: 60});
- * ``` 
+ * ```
  */
-async function updateTokenSight(token, config={}){
-  if(token instanceof Token) token = token.document;
+async function updateTokenSight(token, config = {}) {
+  if (token instanceof Token) token = token.document;
   config = foundry.utils.mergeObject(token.sight, config);
-  if(!(config.visionMode in CONFIG.Canvas.visionModes)) {
+  if (!(config.visionMode in CONFIG.Canvas.visionModes)) {
     ui.notifications.error(`Vision mode: ${config.visionMode}, is not a valid vision mode.`);
     return null;
   }
@@ -93,15 +95,15 @@ function shuffleArray(original) {
   return arr;
 }
 
-function _sortFunction(a,b, lowToHigh){
-  if(typeof(a) === "number") {
-    if(a>b) return lowToHigh ?  1 : -1;
-    else if(a<b) return lowToHigh ? -1 :  1;
+function _sortFunction(a, b, lowToHigh) {
+  if (typeof (a) === "number") {
+    if (a > b) return lowToHigh ? 1 : -1;
+    else if (a < b) return lowToHigh ? -1 : 1;
     else return 0;
   }
-  if(typeof(a) === "string") {
+  if (typeof (a) === "string") {
     return lowToHigh ? a.localeCompare(b) : b.localeCompare(a);
-  }   
+  }
   console.error(`value to sort is not of type String or type Number`);
   return 0; // keeps element in the same spot.
 }
@@ -118,7 +120,7 @@ function _sortFunction(a,b, lowToHigh){
  * const testObj = [{x:5},{x:3},{x:2},{x:6},{x:1},{x:4}];
  * const testNumbers = [3,2,4,6,1,5];
  * const testString = ["Aardvark", "Zebra", "Elephant", "Orang Utan"];
- * 
+ *
  * const sortedTest = polo.utils.sortArray(test, {key: "system.price.value"}); // result: varies on the input but should be cheap to expensive in DND5e.
  * const sortedTestObj = polo.utils.sortArray(testObj, {key: "x", lowToHigh: false}); // result: [{x:6},{x:5},{x:4},{x:3},{x:2},{x:1}];
  * const sortedTestString = polo.utils.sortArray(testString); // result: ["Aardvark", "Elephant", "Orang Utan", "Zebra"]
@@ -127,13 +129,13 @@ function _sortFunction(a,b, lowToHigh){
  * ```
  * @returns {array}                      Sorted array.
  */
-function sortArray(original, {key=null, lowToHigh=true}={}){
+function sortArray(original, {key = null, lowToHigh = true} = {}) {
   let arr = [...original];
-  if(typeof key !== "string") return arr.sort((a,b) => _sortFunction(a,b,lowToHigh));
-  else return arr.sort((a,b)=>{
+  if (typeof key !== "string") return arr.sort((a, b) => _sortFunction(a, b, lowToHigh));
+  else return arr.sort((a, b) => {
     const x = foundry.utils.getProperty(a, key);
     const y = foundry.utils.getProperty(b, key);
-    return _sortFunction(x,y,lowToHigh)
+    return _sortFunction(x, y, lowToHigh)
   });
 }
 
@@ -141,12 +143,12 @@ function sortArray(original, {key=null, lowToHigh=true}={}){
  * Function that changes "/my/awesome/filepath/epic-image.png" to "Epic Image",
  * or "/my/awesome/filepath/epic_sound.ogg" to "Epic Sound",
  * or "/my/awesome/filepath/epic%20video.webm" to "Epic Video"
- * By simply wrapping FoundryVTT's AudioHelper.getDefaultSoundName(path) function, 
+ * By simply wrapping FoundryVTT's AudioHelper.getDefaultSoundName(path) function,
  * which confuses people to think it is just for sounds.
  * @param {string} path                       Path of image/video/sound etc.
  * @returns {string}                          The changed name.
  */
-function getDefaultName(path){
+function getDefaultName(path) {
   return AudioHelper.getDefaultSoundName(path);
 }
 
@@ -156,9 +158,9 @@ function getDefaultName(path){
  * @param {Array<user,string>} [users=[]]     Array of users or user ids.
  * @param {number} [volume=1]                 Volume value between: 0-1.
  * @param {boolean} [loop=true]               Loop or not, default false.
- *  
+ *
  */
-function playSoundForOthers(src, users=[], {volume=1, loop=false}={}) {
+function playSoundForOthers(src, users = [], {volume = 1, loop = false} = {}) {
   const ids = users.reduce((acc, u) => {
     const id = u instanceof User ? u.id : game.users.has(u) ? u : null;
     if (id) acc.push(id);

--- a/styles/sequence-picker.css
+++ b/styles/sequence-picker.css
@@ -13,7 +13,7 @@
   height: 50px;
   border: none;
 }
-.sequence-picker .link img.inactive {
+.polo-utils-sequence-picker .link img.inactive {
   filter: grayscale(1);
 }
 .sequence-picker .label {

--- a/styles/sequence-picker.css
+++ b/styles/sequence-picker.css
@@ -1,0 +1,22 @@
+/** TARGET SEQUENCE PICKER */
+.sequence-picker {
+  height: auto !important;
+  width: 200px;
+}
+.sequence-picker .link {
+  padding: 0.5em 0;
+  text-align: center;
+}
+.sequence-picker .link img {
+  border-radius: 2em;
+  width: 50px;
+  height: 50px;
+  border: none;
+}
+.sequence-picker .link img.inactive {
+  filter: grayscale(1);
+}
+.sequence-picker .label {
+  font-family: "Modesto Condensed";
+  font-size: 35px;
+}

--- a/styles/sequence-picker.css
+++ b/styles/sequence-picker.css
@@ -16,7 +16,7 @@
 .polo-utils-sequence-picker .link img.inactive {
   filter: grayscale(1);
 }
-.sequence-picker .label {
+.polo-utils-sequence-picker .label {
   font-family: "Modesto Condensed";
   font-size: 35px;
 }

--- a/styles/sequence-picker.css
+++ b/styles/sequence-picker.css
@@ -3,7 +3,7 @@
   height: auto !important;
   width: 200px;
 }
-.sequence-picker .link {
+.polo-utils-sequence-picker .link {
   padding: 0.5em 0;
   text-align: center;
 }

--- a/styles/sequence-picker.css
+++ b/styles/sequence-picker.css
@@ -1,5 +1,5 @@
 /** TARGET SEQUENCE PICKER */
-.sequence-picker {
+.polo-utils-sequence-picker {
   height: auto !important;
   width: 200px;
 }

--- a/styles/sequence-picker.css
+++ b/styles/sequence-picker.css
@@ -7,7 +7,7 @@
   padding: 0.5em 0;
   text-align: center;
 }
-.sequence-picker .link img {
+.polo-utils-sequence-picker .link img {
   border-radius: 2em;
   width: 50px;
   height: 50px;

--- a/styles/sequence-picker.css
+++ b/styles/sequence-picker.css
@@ -1,7 +1,10 @@
 /** TARGET SEQUENCE PICKER */
 .polo-utils-sequence-picker {
-  height: auto !important;
+  height: auto;
   width: 200px;
+}
+.polo-utils-sequence-picker .links {
+  border: 2px inset;
 }
 .polo-utils-sequence-picker .link {
   padding: 0.5em 0;
@@ -12,11 +15,9 @@
   width: 50px;
   height: 50px;
   border: none;
+  cursor: pointer;
 }
-.polo-utils-sequence-picker .link img.inactive {
+.polo-utils-sequence-picker .link img:not(.active) {
   filter: grayscale(1);
-}
-.polo-utils-sequence-picker .label {
-  font-family: "Modesto Condensed";
-  font-size: 35px;
+  cursor: default;
 }

--- a/templates/applications/sequence-picker.hbs
+++ b/templates/applications/sequence-picker.hbs
@@ -8,6 +8,6 @@
     {{/each}}
   </div>
   <button data-action="submit">
-    <i class="fa-solid fa-check"></i> {{localize "POLO.AllGucci"}}
+    <i class="fa-solid fa-check"></i> {{localize "POLO.Done"}}
   </button>
 </div>

--- a/templates/applications/sequence-picker.hbs
+++ b/templates/applications/sequence-picker.hbs
@@ -1,9 +1,8 @@
 <div class="content">
-  <span class="label">{{localize "POLO.SequencePicker"}}</span>
   <div class="links">
     {{#each sequence as |link idx|}}
     <div class="link">
-      <img src="{{link.img}}" data-idx="{{idx}}" {{#unless link.point}} class="inactive" {{/unless}}>
+      <img src="{{link.img}}" data-idx="{{idx}}" {{#if link.point}} class="active" {{/if}}>
       {{#if link.point}}<div class="point">({{link.point.x}}, {{link.point.y}})</div>{{/if}}
     </div>
     {{/each}}

--- a/templates/applications/sequence-picker.hbs
+++ b/templates/applications/sequence-picker.hbs
@@ -1,0 +1,14 @@
+<div class="content">
+  <span class="label">{{localize "POLO.SequencePicker"}}</span>
+  <div class="links">
+    {{#each sequence as |link idx|}}
+    <div class="link">
+      <img src="{{link.img}}" data-idx="{{idx}}" {{#unless link.point}} class="inactive" {{/unless}}>
+      {{#if link.point}}<div class="point">({{link.point.x}}, {{link.point.y}})</div>{{/if}}
+    </div>
+    {{/each}}
+  </div>
+  <button data-action="submit">
+    <i class="fa-solid fa-check"></i> {{localize "POLO.AllGucci"}}
+  </button>
+</div>


### PR DESCRIPTION
Closes #11

Also fixes some syntax.

Example usage:
```js
const ret = await polo.utils.applications.sequence.create({links: 5});
console.warn(ret);
for(const point of ret) {
  console.warn(point);
  await canvas.ping(point);
}
```